### PR TITLE
Update fbreactor-mk01.lua

### DIFF
--- a/prototypes/buildings/fbreactor-mk01.lua
+++ b/prototypes/buildings/fbreactor-mk01.lua
@@ -2,7 +2,7 @@ RECIPE {
     type = "recipe",
     name = "fbreactor-mk01",
     energy_required = 0.5,
-    enabled = false,
+    enabled = true,
     ingredients = {
         {"boiler", 2},
         {"pipe", 15},
@@ -12,7 +12,7 @@ RECIPE {
     results = {
         {"fbreactor-mk01", 1}
     }
-}:add_unlock('electronics')
+}
 
 ITEM {
     type = "item",


### PR DESCRIPTION
This building is needed to create Pulp Mill Mk01, which is needed for the Latex production in Red science. As such it cannot currently be locked behind research.