### PR TITLE
Enable Recipe for Nitrobenzene

### DIFF
--- a/prototypes/fluids/nitrobenzene.lua
+++ b/prototypes/fluids/nitrobenzene.lua
@@ -2,7 +2,7 @@ RECIPE {
     type = "recipe",
     name = "nitrobenzene",
     category = "fbreactor",
-    enabled = false,
+    enabled = true,
     energy_required = 4,
     ingredients = {
         {type = "fluid", name = "benzene", amount = 50},


### PR DESCRIPTION
Nitrobenzene recipe is not enabled, but is needed for kevlar production.