### PR TITLE
Fix pipe-to-ground fast replace group

### DIFF
--- a/prototypes/pipes/ht-pipes.lua
+++ b/prototypes/pipes/ht-pipes.lua
@@ -1,5 +1,3 @@
-data.raw["pipe-to-ground"]["pipe-to-ground"].fast_replaceable_group = "pipe-to-ground"
-
 local function py_pipepictures()
     return {
         straight_vertical_single = {
@@ -346,7 +344,7 @@ ENTITY {
             percent = 100
         }
     },
-    fast_replaceable_group = "pipe-to-ground",
+    fast_replaceable_group = "pipe",
     collision_box = {{-0.29, -0.29}, {0.29, 0.2}},
     selection_box = {{-0.5, -0.5}, {0.5, 0.5}},
     fluid_box = {


### PR DESCRIPTION
Has to be the same as the PyInd pipes, so it doesn't crash