### PR TITLE
Nexelit Battery Recharge Fix

### DIFF
--- a/prototypes/recipes/recipes.lua
+++ b/prototypes/recipes/recipes.lua
@@ -3613,7 +3613,7 @@ RECIPE {
     name = 'nexelit-battery-recharge',
     category = 'pa',
     enabled = false,
-    energy_required = 5,
+    energy_required = 0.8,
     ingredients = {
         {type = 'item', name = 'used-nexelit-battery', amount = 1},
         {type = 'item', name = 'nexelit-plate', amount = 3},


### PR DESCRIPTION
Changing the energy required from 5 to 0.8. This makes the mk4 particle accelerator (if it's ever enabled again) 100% efficient at recharging the batteries. (625MW at 0.8s is 500MJ to recharge a 500MJ battery). The mk1 particle accelerator is then 62.5% efficent (1000MW at 0.8s is 800MJ to recharge a 500MJ battery)