### PR TITLE
Miners no longer take simik related modules

### DIFF
--- a/prototypes/buildings/phosphate-mine.lua
+++ b/prototypes/buildings/phosphate-mine.lua
@@ -57,7 +57,7 @@ ENTITY {
     module_specification = {
         module_slots = 4
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 8,
     energy_source =
     {

--- a/prototypes/buildings/rare-earth-mine.lua
+++ b/prototypes/buildings/rare-earth-mine.lua
@@ -46,7 +46,7 @@ ENTITY {
     module_specification = {
         module_slots = 4
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 5,
     energy_source = {
         type = "electric",


### PR DESCRIPTION
This is done by making these modules increase pollution output, and forbidding pollution modules in these miners.