### PR TITLE
Made clay hidden from player crafting instead of hidden.

### DIFF
--- a/prototypes/buildings/clay-pit-mk01.lua
+++ b/prototypes/buildings/clay-pit-mk01.lua
@@ -121,3 +121,5 @@ ENTITY {
         apparent_volume = 2.5
     }
 }
+data.raw.recipe["clay"].hidden = false
+data.raw.recipe["clay"].hide_from_player_crafting = true


### PR DESCRIPTION
As per KiwiHawk's suggestion.

Looks like the 'fixed_recipe' setting auto-generates a recipe, as I can't find it's actual definition anywhere else.

(partially) resolves pyanodon/pybugreports#120