### PR TITLE
Fix recycling prerequisite

### DIFF
--- a/prototypes/updates/base-updates.lua
+++ b/prototypes/updates/base-updates.lua
@@ -2,6 +2,10 @@
 data.raw.technology["processing-unit"].hidden = true
 data.raw.technology["processing-unit"].enabled = false
 
+if mods.quality then
+    TECHNOLOGY("recycling"):remove_prereq("processing-unit")
+end
+
 TECHNOLOGY("exoskeleton-equipment"):remove_prereq("processing-unit")
 TECHNOLOGY("power-armor"):remove_prereq("processing-unit")
 TECHNOLOGY("effect-transmission"):remove_prereq("processing-unit")


### PR DESCRIPTION
- Recycling normally requires processing-unit which is removed by pyhightech so simply remove the prerequisite in that case
- Fixes https://github.com/pyanodon/pybugreports/issues/1006